### PR TITLE
removed 100% from readme intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RouterChat 1.1.2
-A 100% free local OpenRouter chat interface. Strictly BYOK. 
+A free local OpenRouter chat interface. Strictly BYOK. 
 
 ## Disclaimer
 


### PR DESCRIPTION
Removes `100%` from the README introduction. Documentation-only change prepared with Codex assistance.